### PR TITLE
Drop support for ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rvm:
   - 2.3.0
   - rbx-2
 env:
-  - RAILS_VER=3.2.19
-  - RAILS_VER=4.2.1
+  - RAILS_VER=3.2.22.2
+  - RAILS_VER=4.2.6
   - NO_RAILS=1
 services:
   - rabbitmq
@@ -15,4 +15,4 @@ matrix:
     - rvm: rbx-2
   exclude:
     - rvm: 2.3.0
-      env: RAILS_VER=3.2.19
+      env: RAILS_VER=3.2.22.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bunny', '~> 1.7.0'
+gem 'bunny', '~> 2.3.0'
 gem 'uber', '>= 0.0.14'
 gem 'virtus'
 gem 'facets', require: false
@@ -24,7 +24,6 @@ group :development do
     gem 'minitest', rails_ver < '4.0' ? '~> 4.7.5' : '~> 5.4.2'
     gem 'minitest-rails', rails_ver < '4.0' ? '~> 1.0.1' : '~> 2.1.1'
   else
-    #gem 'rails', '>= 3.2.15'
     gem 'minitest', '>= 4.7.5'
     gem 'minitest-reporters', '>= 0.5.0'
   end


### PR DESCRIPTION
With this pull request I'd like to open a discussion about dropping support for Ruby 1.9.x. My point are following:
- Ruby 1.9 is long dead
- Bunny 2.3.0 (which does not support 1.9) shows big performance improvement for tochtli in my tests.

Reasons against:
- ~~@totrash said [here](https://github.com/PuzzleFlow/tochtli/pull/5#discussion_r43108091) that they need support for 1.9 because of using it in production.~~

However, this project seen no development in last few months and I understand that current state of it is enough for them (if they are still using it; can you confirm?). In any case, we might create an LTS branch for 1.9 version and you'd be responsible for cherry-picking changes you like from master.
